### PR TITLE
Virtual pages without translations break plugin

### DIFF
--- a/src/xmlsitemap.php
+++ b/src/xmlsitemap.php
@@ -390,10 +390,14 @@ class XMLSitemap
         if ( $langcode == '--' ) {
           static::addComment( $r, '(--) "' . $p->title() . '"' );
         } else {
-          static::addComment( $r, '(' . $langcode . ') "' . $p->content( $langcode )-> title() . '"' );
-
-          // skip becaue no translation available
-          if ( static::$optionNOTRA == true && ! $p->translation( $langcode )->exists() ) {
+          // virtual pages result `null` for `->translation($lancode)`
+          if (!is_null($p->translation($langcode))) {
+            // skip becaue no translation available
+            if ( static::$optionNOTRA == true && ! $p->translation( $langcode )->exists() ) {
+              static::addComment( $r, 'excluding because translation not available' );
+              continue;
+            }
+          } else {
             static::addComment( $r, 'excluding because translation not available' );
             continue;
           }
@@ -469,11 +473,16 @@ class XMLSitemap
         $r .= '  <xhtml:link rel="alternate" hreflang="x-default" href="' . $p->urlForLanguage( kirby()->language()->code() ) . '" />' . "\n";
         // localized languages: <xhtml:link rel="alternate" hreflang="en" href="http://www.example.com/"/>
         foreach ( kirby()->languages() as $l ) {
-          if ( static::$optionNOTRA == true && ! $p->translation( $l->code() )->exists() ) {
-            $r .= '  <!-- no translation for     hreflang="' . $l->code() . '" -->' . "\n";
+          // virtual pages result `null` for `->translation($lancode)`
+          if (!is_null($p->translation($langcode))) {
+            if ( static::$optionNOTRA == true && ! $p->translation( $l->code() )->exists() ) {
+              $r .= '  <!-- no translation for     hreflang="' . $l->code() . '" -->' . "\n";
+            } else {
+              // Note: Contort PHP locale to hreflang-required form
+              $r .= '  <xhtml:link rel="alternate" hreflang="' . static::getHreflangFromLocale( static::localeFromLang( $l ) ) . '" href="' . $p->urlForLanguage( $l->code() ) . '" />' . "\n";
+            }
           } else {
-            // Note: Contort PHP locale to hreflang-required form
-            $r .= '  <xhtml:link rel="alternate" hreflang="' . static::getHreflangFromLocale( static::localeFromLang( $l ) ) . '" href="' . $p->urlForLanguage( $l->code() ) . '" />' . "\n";
+            $r .= '  <!-- no translation for     hreflang="' . $l->code() . '" -->' . "\n";
           }
         }
       }//end if


### PR DESCRIPTION
When you use virtual pages that don't have translations, sitemap.xml returns an error on line 478: `Call to a member function exists() on null`. So I added an extra condition which checks for just that.